### PR TITLE
Fix unlimited retries check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Ewon Flexy Automatic Code Retry Library Changelog
 
+## v1.3
+### Major Changes
+- Bug Fix: Fixed unlimited retries capability being limited
+
 ## v1.2
 ### Minor Changes
 - Feature: Add method to get current try number

--- a/src/main/java/com/hms_networks/americas/sc/retry/AutomaticRetryCode.java
+++ b/src/main/java/com/hms_networks/americas/sc/retry/AutomaticRetryCode.java
@@ -43,7 +43,8 @@ public abstract class AutomaticRetryCode {
         shouldRun = false;
       } else if (state == AutomaticRetryState.ERROR_RETRY) {
         // Check if above retry limit, if not or unlimited retries enabled, increment retry counter
-        if (retryNumber != MAX_RETRIES_UNLIMITED_VALUE && retryNumber >= getMaxRetries()) {
+        final int maxRetries = getMaxRetries();
+        if (maxRetries != MAX_RETRIES_UNLIMITED_VALUE && retryNumber >= maxRetries) {
           // If above retry limit, stop attempting
           shouldRun = false;
         } else {

--- a/src/main/java/com/hms_networks/americas/sc/retry/package.html
+++ b/src/main/java/com/hms_networks/americas/sc/retry/package.html
@@ -3,7 +3,7 @@
 Utility classes to manage the automatic retry of implemented code using a specified algorithm or pre-defined algorithm
 (i.e. exponential or linear).
 
-@version 1.2
+@version 1.3
 @author HMS Networks, MU Americas Solution Center
 </BODY>
 </HTML>


### PR DESCRIPTION
The unlimited retries check was performing
a comparison against the wrong target, which
broke the unlimited retries functionality.